### PR TITLE
Working build with tbd_build

### DIFF
--- a/tbd_build/build/build.go
+++ b/tbd_build/build/build.go
@@ -1,0 +1,49 @@
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/JimGaylard/tbd/tbd_mktmp/mktmp"
+)
+
+func Build(tree, ciPath string) error {
+	// TODO: delete tmpDir after run
+	walkFunc := func(path string, info os.FileInfo, e error) error {
+		if e != nil {
+			return e
+		}
+
+		if !info.IsDir() || path == "ci" {
+			return nil
+		}
+
+		tmpDir, err := mktmp.CheckoutTmp(tree)
+		if err != nil {
+			return err
+		}
+
+		ciCmd := filepath.Join(tmpDir, path, "run")
+
+		refPrefix := filepath.Join("refs", "builds", tree, filepath.Base(path))
+		cmd := exec.Command("tbd_run", "-propagateErrors", "-prefix", refPrefix, ciCmd)
+
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	err := filepath.Walk(ciPath, walkFunc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tbd_build/tbd_build.go
+++ b/tbd_build/tbd_build.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/JimGaylard/tbd/tbd_build/build"
+)
+
+func init() {
+	flag.Usage = func() {
+		fmt.Printf("Usage of %s:\n", os.Args[0])
+		fmt.Println("Builds the tbd project")
+		fmt.Printf("%s [options...] <tree>", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	config.ciDir = flag.String("ci_dir", "ci", "ci directory")
+}
+
+type Config struct {
+	ciDir *string
+}
+
+var config Config
+
+func main() {
+	flag.Parse()
+
+	if len(os.Args) != 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	err := build.Build(os.Args[1], *config.ciDir)
+	if err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+}

--- a/tbd_build/tbd_build.man
+++ b/tbd_build/tbd_build.man
@@ -3,7 +3,8 @@
 tbd_build \- Run the tbd build process.
 .SH SYNOPSIS
 .TP
-.B tbd build <command>
+.B tbd build [options] <tree-id>
+
 .SH DESCRIPTION
 tbd_build runs the main build process. For each subdirectory within the ci/
 folder of the current working directory, tbd will check out a copy of your
@@ -12,7 +13,11 @@ the ouput of those commands to git (see tbd-run(1)).
 .PP
 .SH OPTIONS
 .TP
-\-h display a short help text
+\-h
+display a short help text
+.TP
+\-ci-dir
+ci directory for your project
 .PP
 .SH "TBD"
 .sp

--- a/tbd_mktmp/mktmp/mktmp.go
+++ b/tbd_mktmp/mktmp/mktmp.go
@@ -23,6 +23,9 @@ func CheckoutTmp(tree string) (string, error) {
 	}
 
 	treeId, err := repo.LookupTree(treeOid)
+	if err != nil {
+		return "", err
+	}
 
 	var checkoutOpts git.CheckoutOpts
 

--- a/tbd_run/tbd_run.go
+++ b/tbd_run/tbd_run.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/JimGaylard/tbd/tbd_save_tree/save_tree"
 	"io"
 	"os"
 	"os/exec"
@@ -81,8 +80,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	treeBeforeBuild, err := save_tree.Worktree()
-	die(err)
 	cmd := exec.Command(flag.Args()[0], flag.Args()[1:]...)
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -105,11 +102,9 @@ func main() {
 		}()
 	}
 
-	prefix := *config.prefix + treeBeforeBuild
-
-	updateRef(prefix+"/STDOUT", hashFor(&stdout))
-	updateRef(prefix+"/STDERR", hashFor(&stderr))
-	updateRef(prefix+"/OUTPUT", hashFor(&combined))
+	updateRef(*config.prefix+"/STDOUT", hashFor(&stdout))
+	updateRef(*config.prefix+"/STDERR", hashFor(&stderr))
+	updateRef(*config.prefix+"/OUTPUT", hashFor(&combined))
 }
 
 func run(cmd *exec.Cmd) {


### PR DESCRIPTION
tbd_build takes a tree object and for each dir in ./ci it checks out
the tree to a tmp dir and runs the ./ci/stage/run command.

It uses tbd_run to store the output in the git object database with
pointers in the refs/builds/<tree_id>/stage directory.
